### PR TITLE
nit: add missing paren

### DIFF
--- a/monet.el
+++ b/monet.el
@@ -2,7 +2,7 @@
 
 ;; Author: Stephen Molitor <stevemolitor@gmail.com>
 ;; Version: 0.0.1
-;; Package-Requires: ((emacs "30.0") (websocket "1.15")
+;; Package-Requires: ((emacs "30.0") (websocket "1.15"))
 ;; Keywords: tools, ai
 ;; URL: https://github.com/stevemolitor/monet
 


### PR DESCRIPTION
This was preventing the websocket dependency from being installed.

Fix: #3