### PR TITLE
Fix evil-mode keybinding conflicts in diff tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,13 @@ Available customizable tools:
 - `monet-get-workspace-folders-tool` - List project directories
 - `monet-diagnostics-tool` - Get diagnostics (defaults to Flymake/Flycheck)
 
+_Important:_ to customize the diff tool to use ediff, you must set both the diff tool and the diff cleanup tool:
+
+```elisp
+(setq monet-diff-tool #'monet-ediff-tool)
+(setq monet-diff-cleanup-tool #'monet-ediff-cleanup-tool)
+```
+
 #### Custom Diff Tool
 
 You can customize how Monet displays diffs by providing your own diff tool functions:


### PR DESCRIPTION
## Summary
Fixes #7 - Keybindings not working in evil-mode for both ediff and simple diff tools.

## Problem
When evil-mode is enabled, the diff tool keybindings (y/q for simple diff, C-c C-c/q for ediff) don't work because evil-mode's keymaps take precedence over buffer-local keymaps.

## Solution  
- Created `monet-diff-mode` minor mode with its own keymap for high precedence
- Added `monet--setup-diff-keybindings` helper function that:
  - Sets up keybindings in the minor mode map
  - If evil-mode is active, also defines keys for normal and motion states using `evil-local-set-key`
  - For ediff control buffers, switches to emacs state where evil keymaps are inactive
- Updated both `monet-simple-diff-tool` and `monet-ediff-tool` to use the new helper

The solution is backward compatible and works without evil-mode installed.