### PR TITLE
Fix evil-mode visual line selection counting

### DIFF
--- a/monet.el
+++ b/monet.el
@@ -1134,14 +1134,22 @@ This is called from post-command-hook."
            (point-pos (point))
            (start-pos (if (use-region-p) (region-beginning) point-pos))
            (end-pos (if (use-region-p) (region-end) point-pos))
-           (text (if (use-region-p)
-                     (buffer-substring-no-properties start-pos end-pos)
-                   ""))
-           ;; Check if we're in evil-mode visual line mode
+           ;; Check if we're in evil-mode visual line mode with active selection
            (in-evil-visual-line (and (bound-and-true-p evil-mode)
                                       (bound-and-true-p evil-visual-selection)
-                                      (eq evil-visual-selection 'line)))
-           ;; Adjust end position for evil visual line mode
+                                      (eq evil-visual-selection 'line)
+                                      ;; Must also have an active region or be in visual state
+                                      (or (use-region-p)
+                                          (and (boundp 'evil-visual-state-minor-mode)
+                                               evil-visual-state-minor-mode))))
+           ;; Adjust positions for evil visual line mode
+           (adjusted-start-pos (if in-evil-visual-line
+                                   ;; In visual line mode, ensure start is at beginning of line
+                                   (save-excursion
+                                     (goto-char start-pos)
+                                     (beginning-of-line)
+                                     (point))
+                                 start-pos))
            (adjusted-end-pos (if in-evil-visual-line
                                  ;; In visual line mode, end-pos is at the start of the last
                                  ;; selected line. We need to move it to the END of that line
@@ -1152,10 +1160,13 @@ This is called from post-command-hook."
                                    (end-of-line)
                                    (point))
                                end-pos))
-           (start-line (1- (line-number-at-pos start-pos)))
+           (text (if (or (use-region-p) in-evil-visual-line)
+                     (buffer-substring-no-properties adjusted-start-pos adjusted-end-pos)
+                   ""))
+           (start-line (1- (line-number-at-pos adjusted-start-pos)))
            (end-line (1- (line-number-at-pos adjusted-end-pos)))
            (start-col (save-excursion
-                        (goto-char start-pos)
+                        (goto-char adjusted-start-pos)
                         (current-column)))
            (end-col (save-excursion
                       (goto-char adjusted-end-pos)
@@ -1164,7 +1175,7 @@ This is called from post-command-hook."
                                   (character . ,start-col)))
                         (end . ((line . ,end-line)
                                 (character . ,end-col)))
-                        (isEmpty . ,(if (use-region-p) :json-false t))))
+                        (isEmpty . ,(if (or (use-region-p) in-evil-visual-line) :json-false t))))
            (file-url (concat "file://" file-path)))
       `((text . ,text)
         (filePath . ,file-path)


### PR DESCRIPTION
## Summary
- Fixes incorrect line counting when using evil-mode's visual line selection (V command)
- Resolves issue where selecting multiple lines with V + j would undercount the selected lines

## Problem
When using evil-mode's visual line selection:
1. Press `V` to start line selection - would show "0 lines selected" instead of "1 line"
2. Press `j` to extend to next line - would show "1 line selected" instead of "2 lines"

The issue was that evil-mode places `region-end` at the beginning of the last selected line, not at its end, causing the line count calculation to be incorrect.

## Solution
The fix detects when evil-mode visual line selection is active (by checking `evil-visual-selection` equals `'line`) and adjusts the end position to the end of the current line for accurate line counting.

## Test plan
1. Enable evil-mode in Emacs
2. Open a file with monet-mode active
3. Press `V` to start visual line selection - should show "1 line selected"
4. Press `j` to extend selection - should show "2 lines selected"
5. Continue pressing `j` - line count should increment correctly

Fixes #14