### PR TITLE
Add option to disable diff tools entirely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [Unreleased]
+
+### Added
+- Option to disable diff tools entirely by setting `monet-diff-tool` to `nil`
+  - When disabled, Claude uses its built-in diff display instead of creating diff views in Emacs
+  - Diff-related MCP tools (`openDiff` and `closeAllDiffTabs`) are conditionally excluded from the tools list

--- a/README.md
+++ b/README.md
@@ -205,6 +205,16 @@ You can customize how Monet displays diffs by providing your own diff tool funct
 
 The diff tool function should take: `(old-file-path new-file-path new-file-contents on-accept on-quit)` and return a context object. The cleanup function takes that context object for cleanup.
 
+#### Disabling Diff Tools
+
+To disable Monet's diff functionality entirely and use Claude's built-in diff display instead:
+
+```elisp
+(setq monet-diff-tool nil)
+```
+
+When disabled, Claude will show proposed changes in its native interface rather than creating diff views in Emacs.
+
 ## How It Works
 
 Monet creates a WebSocket server that Claude Code connects to via MCP. This allows Claude to:


### PR DESCRIPTION
## Summary
- Add ability to set `monet-diff-tool` to `nil` to disable diff functionality
- When disabled, Claude uses its built-in diff display instead of creating diff views in Emacs
- Conditionally exclude `openDiff` and `closeAllDiffTabs` MCP tools when diff tools are disabled
- Update README with documentation on how to disable diff tools
- Add CHANGELOG entry

## Test plan
- [ ] Test with `monet-diff-tool` set to a function (default behavior)
- [ ] Test with `monet-diff-tool` set to `nil` (diff tools disabled)
- [ ] Verify MCP tools list excludes diff tools when disabled
- [ ] Confirm Claude uses built-in diff when tools are disabled