### PR TITLE
Add do-not-disturb mode for diff displays

### DIFF
--- a/monet.el
+++ b/monet.el
@@ -1329,6 +1329,7 @@ Returns the window displaying the diff buffer."
                     (not (string= originating-tab current-tab)))
                (and originating-frame
                     (not (eq originating-frame current-frame)))))
+      (message "Diff created but not displayed (do-not-disturb mode)")
       nil)  ; Don't display the buffer
      ;; If we have an originating tab, try to display in that tab
      (originating-tab

--- a/test-diff-visibility.el
+++ b/test-diff-visibility.el
@@ -1,8 +1,14 @@
-;;; test-diff-visibility.el --- Test script for context-aware diff hiding
+;;; test-diff-visibility.el --- Test script for context-aware diff hiding  -*- lexical-binding: t; -*-
 
 ;; This test demonstrates the context-aware diff hiding feature
 
-;;; Test Setup
+;;; Commentary:
+
+;; This test script verifies the context-aware diff hiding functionality
+;; in monet.el.  It tests whether diffs are properly shown/hidden based
+;; on the current buffer context.
+
+;;; Code:
 (require 'monet)
 
 ;; Enable the feature
@@ -38,9 +44,9 @@
     
     ;; Test 1: Check if buffer is relevant to session
     (message "\nTest 1: Buffer relevance check")
-    (message "  Buffer in session dir: %s" 
-             (monet--is-buffer-relevant-to-session-p 
-              test-buffer 
+    (message "  Buffer in session dir: %s"
+             (monet--is-buffer-relevant-to-session-p
+              test-buffer
               "/Users/steve/repos/monet"
               "/Users/steve/repos/monet/test.el"))
     


### PR DESCRIPTION
## Summary
- Adds `monet-do-not-disturb` customization option to prevent diff buffers from displaying in tabs/frames other than where the Claude session was started
- Fixes checkdoc warnings and compilation issues throughout the codebase
- Adds user feedback when diffs are suppressed by do-not-disturb mode

## Changes
1. **New do-not-disturb feature**: When `monet-do-not-disturb` is set to `t`, diff buffers will only display in the tab/frame where the Claude session originated. This prevents disruption when working in other tabs/frames.

2. **Session context tracking**: Sessions now track their originating buffer, tab, and frame to enable the do-not-disturb functionality.

3. **Code quality improvements**:
   - Fixed all checkdoc warnings (proper parameter documentation, backtick quoting)
   - Removed trailing whitespace
   - Added lexical-binding to test files
   - Added required Commentary/Code sections

4. **User feedback**: When a diff is suppressed due to do-not-disturb mode, a message is displayed in the minibuffer to inform the user.

## Test plan
- [ ] Test that diffs display normally when `monet-do-not-disturb` is nil
- [ ] Test that diffs are suppressed in different tabs when `monet-do-not-disturb` is t
- [ ] Test that diffs are suppressed in different frames when `monet-do-not-disturb` is t
- [ ] Verify the feedback message appears when diffs are suppressed
- [ ] Run `make clean && make all` to ensure no compilation warnings