### PR TITLE
Fix diff tool failure with file paths containing spaces

### DIFF
--- a/monet.el
+++ b/monet.el
@@ -1378,7 +1378,7 @@ Returns the diff context object for later used by the cleanup tool."
     ;; Create the diff
     (let* ((diff-buffer-name (format "*Diff: %s*" (file-name-nondirectory old-file-path)))
            (diff-buffer (get-buffer-create diff-buffer-name t))
-           (switches `("-u" "--label" ,old-file-path "--label" ,(or new-file-path old-file-path)))
+           (switches `("-u" "--label" ,(shell-quote-argument old-file-path) "--label" ,(shell-quote-argument (or new-file-path old-file-path))))
            ;; syntax highlighting
            (diff-font-lock-syntax 'hunk-also)
            (diff-font-lock-prettify t)


### PR DESCRIPTION
The monet-simple-diff-tool function was failing when file paths contained
spaces because the paths in --label arguments weren't properly quoted for
shell execution.

This adds shell-quote-argument to properly escape the file paths, fixing the issue with files in directories like 'Mobile Documents'.