### PR TITLE
Fix line number reporting when narrowing is in effect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.0.3]
+
+### Fixed
+  - Fix line number reporting when narrowing is in effect
+
+## [0.0.2]
 
 ### Added
-- Option to disable diff tools entirely by setting `monet-diff-tool` to `nil`
+  - Option to disable diff tools entirely by setting `monet-diff-tool` to `nil`
   - When disabled, Claude uses its built-in diff display instead of creating diff views in Emacs
   - Diff-related MCP tools (`openDiff` and `closeAllDiffTabs`) are conditionally excluded from the tools list

--- a/monet.el
+++ b/monet.el
@@ -1,7 +1,7 @@
 ;;; monet.el  --- Claude Code MCP over websockets   -*- lexical-binding:t -*-
 
 ;; Author: Stephen Molitor <stevemolitor@gmail.com>
-;; Version: 0.0.2
+;; Version: 0.0.3
 ;; Package-Requires: ((emacs "30.0") (websocket "1.15"))
 ;; Keywords: tools, ai
 ;; URL: https://github.com/stevemolitor/monet
@@ -1202,8 +1202,8 @@ This is called from `post-command-hook'."
            (text (if (or (use-region-p) in-evil-visual-line)
                      (buffer-substring-no-properties adjusted-start-pos adjusted-end-pos)
                    ""))
-           (start-line (1- (line-number-at-pos adjusted-start-pos)))
-           (end-line (1- (line-number-at-pos adjusted-end-pos)))
+           (start-line (1- (line-number-at-pos adjusted-start-pos t)))
+           (end-line (1- (line-number-at-pos adjusted-end-pos t)))
            (start-col (save-excursion
                         (goto-char adjusted-start-pos)
                         (current-column)))
@@ -1798,8 +1798,8 @@ If URI is nil, gets diagnostics for all open files."
                        (end (flymake-diagnostic-end diag))
                        (type (flymake-diagnostic-type diag))
                        (text (flymake-diagnostic-text diag))
-                       (start-line (1- (line-number-at-pos beg)))
-                       (end-line (1- (line-number-at-pos end)))
+                       (start-line (1- (line-number-at-pos beg t)))
+                       (end-line (1- (line-number-at-pos end t)))
                        (start-char (save-excursion
                                      (goto-char beg)
                                      (current-column)))


### PR DESCRIPTION
## Summary
- Fixed line number reporting to account for narrowing offset in Emacs buffers

## Test plan
- Test with narrowed buffers to ensure line numbers are reported correctly
- Verify existing functionality still works without narrowing