### PR TITLE
Add configurable option to ignore whitespace in diffs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.0.4]
+
+### Added
+  - `monet-diff-ignore-whitespace` configuration option to ignore whitespace changes in diffs
+  - Helps reduce noise from line ending differences between different operating systems
+  - When enabled, uses `-w` flag with diff command
+
 ## [0.0.3]
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
-## [Unreleased]
+## [0.0.3]
+
+### Fixed
+  - Fix line number reporting when narrowing is in effect
+
+## [0.0.2]
 
 ### Added
-- Option to disable diff tools entirely by setting `monet-diff-tool` to `nil`
+  - Option to disable diff tools entirely by setting `monet-diff-tool` to `nil`
   - When disabled, Claude uses its built-in diff display instead of creating diff views in Emacs
   - Diff-related MCP tools (`openDiff` and `closeAllDiffTabs`) are conditionally excluded from the tools list

--- a/README.md
+++ b/README.md
@@ -155,6 +155,9 @@ You can start multiple sessions per project, or have multiple
 
 ;; Change ediff window split direction
 (setq monet-ediff-split-window-direction 'vertical)  ; Default: 'horizontal
+
+;; Ignore whitespace changes in diffs (helpful for line ending differences)
+(setq monet-diff-ignore-whitespace t)  ; Default: nil
 ```
 
 #### Customizing MCP Tools

--- a/monet.el
+++ b/monet.el
@@ -1,7 +1,7 @@
 ;;; monet.el  --- Claude Code MCP over websockets   -*- lexical-binding:t -*-
 
 ;; Author: Stephen Molitor <stevemolitor@gmail.com>
-;; Version: 0.0.2
+;; Version: 0.0.3
 ;; Package-Requires: ((emacs "30.0") (websocket "1.15"))
 ;; Keywords: tools, ai
 ;; URL: https://github.com/stevemolitor/monet
@@ -1202,8 +1202,8 @@ This is called from `post-command-hook'."
            (text (if (or (use-region-p) in-evil-visual-line)
                      (buffer-substring-no-properties adjusted-start-pos adjusted-end-pos)
                    ""))
-           (start-line (1- (line-number-at-pos adjusted-start-pos)))
-           (end-line (1- (line-number-at-pos adjusted-end-pos)))
+           (start-line (1- (line-number-at-pos adjusted-start-pos t)))
+           (end-line (1- (line-number-at-pos adjusted-end-pos t)))
            (start-col (save-excursion
                         (goto-char adjusted-start-pos)
                         (current-column)))
@@ -1798,8 +1798,8 @@ If URI is nil, gets diagnostics for all open files."
                        (end (flymake-diagnostic-end diag))
                        (type (flymake-diagnostic-type diag))
                        (text (flymake-diagnostic-text diag))
-                       (start-line (1- (line-number-at-pos beg)))
-                       (end-line (1- (line-number-at-pos end)))
+                       (start-line (1- (line-number-at-pos beg t)))
+                       (end-line (1- (line-number-at-pos end t)))
                        (start-char (save-excursion
                                      (goto-char beg)
                                      (current-column)))

--- a/monet.el
+++ b/monet.el
@@ -109,6 +109,13 @@ the diff request."
   :type 'boolean
   :group 'monet-tool)
 
+(defcustom monet-diff-ignore-whitespace nil
+  "When non-nil, ignore whitespace changes when creating diffs.
+This can help reduce noise in diffs caused by line ending differences
+between different operating systems."
+  :type 'boolean
+  :group 'monet-tool)
+
 (defcustom monet-do-not-disturb nil
   "When non-nil, don't display diff buffers in tabs other than the originating tab.
 If the current tab is different from the tab where the Claude session was started,
@@ -1378,7 +1385,7 @@ Returns the diff context object for later used by the cleanup tool."
     ;; Create the diff
     (let* ((diff-buffer-name (format "*Diff: %s*" (file-name-nondirectory old-file-path)))
            (diff-buffer (get-buffer-create diff-buffer-name t))
-           (switches `("-u" "--label" ,(shell-quote-argument old-file-path) "--label" ,(shell-quote-argument (or new-file-path old-file-path))))
+           (switches `(,(if monet-diff-ignore-whitespace "-u -w" "-u") "--label" ,(shell-quote-argument old-file-path) "--label" ,(shell-quote-argument (or new-file-path old-file-path))))
            ;; syntax highlighting
            (diff-font-lock-syntax 'hunk-also)
            (diff-font-lock-prettify t)


### PR DESCRIPTION
## Summary
- Adds `monet-diff-ignore-whitespace` configuration variable to control whether whitespace changes are ignored in diffs
- When enabled, uses the `-w` flag with diff to ignore whitespace changes
- Helps reduce noise in diffs caused by line ending differences between operating systems

## Changes Made
- Added new `defcustom` variable `monet-diff-ignore-whitespace` (defaults to `nil` for backward compatibility)
- Modified diff switches logic in `monet-simple-diff-tool` to conditionally include `-w` flag
- Added comprehensive documentation for the new option

## Test Plan
- [x] Verified Emacs Lisp syntax is correct
- [x] Tested conditional logic produces expected diff switches
- [x] Confirmed backward compatibility (default behavior unchanged)
- [x] Validated that `-w` flag is only added when option is enabled

## Usage
Users can enable this feature by setting:
```elisp
(setq monet-diff-ignore-whitespace t)
```

Fixes #23