### PR TITLE
Autoload monet-start-server-function

### DIFF
--- a/monet.el
+++ b/monet.el
@@ -646,6 +646,7 @@ Returns the session object."
        (message "Failed to start MCP server: %s" (error-message-string err))
        nil))))
 
+;;;###autoload
 (defun monet-start-server-function (key directory)
   "Start a Monet server with KEY in DIRECTORY.
 


### PR DESCRIPTION
It's convenient for this to autoload, so you can do something like:

(add-hook 'claude-code-process-environment-functions #'monet-start-server-function)

without having to require monet.el at startup.