### PR TITLE
Remove extraneous space to fix `package-buffer-info`

### DIFF
--- a/monet.el
+++ b/monet.el
@@ -1,4 +1,4 @@
-;;; monet.el  --- Claude Code MCP over websockets   -*- lexical-binding:t -*-
+;;; monet.el --- Claude Code MCP over websockets   -*- lexical-binding:t -*-
 
 ;; Author: Stephen Molitor <stevemolitor@gmail.com>
 ;; Version: 0.0.3


### PR DESCRIPTION
- Before: `(package-buffer-info)` signals an error "Package lacks a file header"
- After: `(package-buffer-info)` returns a valid package description