### PR TITLE
Add option to persist session after claude code disconnects

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ When claude-code.el starts a new session it will start and associate a Monet ses
 
 ### Session Management
 
-Sessions are automatically cleaned up (killed) when you exit the associated Claude session. When you exit Emacs all sessions are cleaned up. You can stop a session manually via `monet-stop-server` (`C-c q`).
+Sessions are automatically cleaned up (killed) when you exit the associated Claude session. Set `monet-persist-sessions` to `t` to keep sessions alive after Claude disconnects. When you exit Emacs all sessions are cleaned up. You can stop a session manually via `monet-stop-server` (`C-c q`).
 
 ### Example
 
@@ -155,6 +155,9 @@ You can start multiple sessions per project, or have multiple
 
 ;; Change ediff window split direction
 (setq monet-ediff-split-window-direction 'vertical)  ; Default: 'horizontal
+
+;; Keep sessions alive after Claude Code disconnects
+(setq monet-persist-sessions t)  ; Default: nil
 ```
 
 #### Customizing MCP Tools

--- a/monet.el
+++ b/monet.el
@@ -116,6 +116,14 @@ the diff buffer will not be displayed (though it remains accessible in the Claud
   :type 'boolean
   :group 'monet-tool)
 
+(defcustom monet-persist-sessions nil
+  "When non-nil, keep sessions alive after Claude Code disconnects.
+Sessions will persist until manually stopped with `monet-stop-server'
+or Emacs exits. This allows reconnecting to the same server with a
+new Claude Code session."
+  :type 'boolean
+  :group 'monet)
+
 (defcustom monet-get-current-selection-tool 'monet-default-get-current-selection-tool
   "Function to use for getting the current text selection.
 The function should have the signature:
@@ -567,21 +575,26 @@ claude later."
 (defun monet--on-close-server (session _ws)
   "Handle WebSocket WS close for SESSION.
 
-Remove SESSION from `monet--sessions'."
-  (let ((key (monet--session-key session))
-        (port (monet--session-port session)))
-    ;; Remove lockfile
-    (monet--remove-lockfile port)
-    ;; Remove session
-    (remhash key monet--sessions)
-    ;; Remove hooks if no more sessions
-    (when (= 0 (hash-table-count monet--sessions))
-      (remove-hook 'post-command-hook #'monet--track-selection-change)
-      (remove-hook 'post-command-hook #'monet--track-diff-visibility)
-      ;; Cancel visibility timer if active
-      (when monet--diff-visibility-timer
-        (cancel-timer monet--diff-visibility-timer)
-        (setq monet--diff-visibility-timer nil)))))
+When `monet-persist-sessions' is nil, remove SESSION from `monet--sessions'.
+When non-nil, keep the session alive to allow reconnection."
+  (if monet-persist-sessions
+      ;; Keep session alive, just clear the client
+      (setf (monet--session-client session) nil)
+    ;; Default behavior: full cleanup
+    (let ((key (monet--session-key session))
+          (port (monet--session-port session)))
+      ;; Remove lockfile
+      (monet--remove-lockfile port)
+      ;; Remove session
+      (remhash key monet--sessions)
+      ;; Remove hooks if no more sessions
+      (when (= 0 (hash-table-count monet--sessions))
+        (remove-hook 'post-command-hook #'monet--track-selection-change)
+        (remove-hook 'post-command-hook #'monet--track-diff-visibility)
+        ;; Cancel visibility timer if active
+        (when monet--diff-visibility-timer
+          (cancel-timer monet--diff-visibility-timer)
+          (setq monet--diff-visibility-timer nil))))))
 
 (defun monet--on-error-server (session _ws action error)
   "Handle WebSocket error for SESSION with WS during ACTION with ERROR."


### PR DESCRIPTION
## Summary

Add `monet-persist-sessions` option to keep sessions alive after Claude Code
disconnects, allowing reconnection without restarting the server.

## Problem

Closes #33.

When Claude Code disconnects (e.g., exiting the CLI), the monet session is
automatically cleaned up. Users who frequently restart Claude Code sessions while
keeping Emacs running must manually restart the monet server each time before
reconnecting.

## Solution

Add a new customizable variable `monet-persist-sessions` (default `nil`) that, when
enabled, keeps the websocket server running after Claude disconnects. The session
remains available for a new Claude Code session to reconnect via `/ide`.

## Usage

```elisp
(setq monet-persist-sessions t)
```

## Test plan

I first set up my Doom Emacs configuration to use this option: [link to the exact line](https://github.com/TristanFloch/.doom.d/blob/master/config.el#L319).

While multiple monet servers are running on different directories:

- Start a monet server for a new project directory using `monet-start-server`
- Connect to that server using `/ide` in Claude Code (using a standalone terminal)
- Terminate the Claude Code session using `Ctrl+C Ctrl+C`
- Check the monet session is still running using `monet-list-sessions`:
  ```
  doom                 Port: 11617 Connected: No  Initialized: Yes  Directory: /Users/myuser/myproject/
  ```
- Restart Claude Code in the same directory using `ENABLE_IDE_INTEGRATION=t claude` and check it connected to the right session
- Double check the monet sessions list:
  ```
  doom                 Port: 11617 Connected: Yes Initialized: Yes  Directory: /Users/myuser/myproject/
  ```
