### PR TITLE
Use WebSocket ping frames instead of tools/list_changed for keepalive

### DIFF
--- a/monet.el
+++ b/monet.el
@@ -443,10 +443,10 @@ Searches all sessions for the deferred response."
   (run-with-idle-timer 2 nil (lambda () (message nil))))
 
 (defun monet--ping (client)
-  "Send tools/list_changed notification as keepalive to CLIENT."
-  (monet--send-notification
-   client
-   "notifications/tools/list_changed"))
+  "Send WebSocket ping frame as keepalive to CLIENT."
+  (websocket-send client
+                  (make-websocket-frame :opcode 'ping
+                                        :completep t)))
 
 (defun monet--start-ping-timer (session)
   "Start periodic ping timer for SESSION."


### PR DESCRIPTION
The keepalive timer was sending notifications/tools/list_changed every 30 seconds, which caused Claude Code to re-fetch the tool list and clear its cached editor state (file path, cursor position). This made Claude lose track of the user's context on every ping cycle.

Replace the MCP-level notification with a WebSocket-level ping frame, which keeps the connection alive without touching the MCP protocol layer or triggering any state reset in Claude Code.