### PR TITLE
Convert monet-command-map into a prefix map

### DIFF
--- a/monet.el
+++ b/monet.el
@@ -2160,17 +2160,16 @@ This explicitly provides context to Claude Code."
         line-start (file-name-nondirectory file-path)))))
 
 ;;; Minor Mode
-(defvar monet-command-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map "s" #'monet-start-server)
-    (define-key map "q" #'monet-stop-server)
-    (define-key map "Q" #'monet-stop-all-servers)
-    (define-key map "l" #'monet-list-sessions)
-    (define-key map "L" #'monet-enable-logging)
-    (define-key map "D" #'monet-disable-logging)
-    (define-key map "m" #'monet-mention-region)
-    map)
-  "Keymap for Monet mode commands under the prefix key.")
+(defvar-keymap monet-command-map
+  :doc "Keymap for Monet mode commands."
+  :prefix t
+  "s" #'monet-start-server
+  "q" #'monet-stop-server
+  "Q" #'monet-stop-all-servers
+  "l" #'monet-list-sessions
+  "L" #'monet-enable-logging
+  "D" #'monet-disable-logging
+  "m" #'monet-mention-region)
 
 (defun monet--make-mode-map ()
   "Create the mode map with the configured prefix key."


### PR DESCRIPTION
A prefix map may be bound to any key in any map to activate those binds. The user may then bind `monet-command-map` to any key in any map they wish, reducing the need for `monet-mode` (#38).

We can use `defvar-keymap` here, as it was introduced in Emacs 29.1 and we already require Emacs 30.1. We could probably change `monet--make-mode-map` to use `define-keymap`, but it likely wouldn't handle the situation where `monet-prefix-key` is nil. A more complete solution would be to copy the behaviour of outline.el, which defines a `defcustom :set` function which removes the old keybind and sets the new one, but this would be a breaking change for users who are setting the variable with `setq` and not `setopt` or Customize.

Besides `defvar-keymap` and `define-keymap`, the docstring for `define-key` in my Emacs 31.0.90 pretest says that it is a legacy function and to prefer `keymap-set`. It's probably impossible for them to get rid of the old functions, but it may be worth going through and replacing them.